### PR TITLE
Fix FastMCP init for mcp v1.13.1

### DIFF
--- a/opencv_mcp_server/main.py
+++ b/opencv_mcp_server/main.py
@@ -24,8 +24,7 @@ logger = logging.getLogger("opencv-mcp-server")
 
 # Create FastMCP server instance
 mcp = FastMCP(
-    name="opencv-mcp-server",
-    description="MCP server providing OpenCV computer vision capabilities",
+    name="opencv-mcp-server"
 )
 
 def main():


### PR DESCRIPTION
Remove the invalid 'description' parameter from the FastMCP constructor in main.py. This resolves a TypeError in mcp library version 1.13.1 and later, where FastMCP.__init__() does not accept 'description'.

This allows the server to start successfully on stdio transport without errors.

Tested with mcp 1.13.1; server registers all tools and listens as expected.
